### PR TITLE
Add LocalConsumer.  Adresses #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ A library to publish and receive events using postgres and grpc
 * Receive events in order (by `subject`)
 * Receive all previous events on first connect
 * Receive new events in real time 
+
+
+Create a local Event consumer
+* Publish a message to the event topic
+* Consume the message from the event topic
+* Ensure the message received is the same as the message published
+
+Create a persistent Event consumer
+* Publish a message to the event topic
+* Message received is first stored in the database, then sent to the consumer
+
+
+Create a catchup mechanism
+* Request a batch of messages from the server (starting from?)
+* Write each message to the consumer
+* Stop when the catchup mechanism detects that it is overwriting the live messages
+
+Create a processor
+* Verifies that there are no gaps in the event sequence (check the sequence for the earliest unprocessed event until this one)
+* Verifies that there are no earlier unprocessed events for the same subject

--- a/src/main/java/com/p14n/postevent/LocalConsumer.java
+++ b/src/main/java/com/p14n/postevent/LocalConsumer.java
@@ -22,22 +22,16 @@ public class LocalConsumer {
     public void start() throws IOException, InterruptedException {
         Consumer<ChangeEvent<String, String>> consumer = record -> {
             try {
+                var actualObj = mapper.readTree(record.value());
+                var r = actualObj.get("payload").get("after");
 
-                try {
-                    var actualObj = mapper.readTree(record.value());
-                    var r = actualObj.get("payload").get("after");
-
-                    broker.publish(Event.create(r.get("id").asText(),
-                            r.get("source").asText(),
-                            r.get("type").asText(),
-                            r.get("datacontenttype").asText(),
-                            r.get("dataschema").asText(),
-                            r.get("subject").asText(),
-                            r.get("data").binaryValue()));
-
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
+                broker.publish(Event.create(r.get("id").asText(),
+                        r.get("source").asText(),
+                        r.get("type").asText(),
+                        r.get("datacontenttype").asText(),
+                        r.get("dataschema").asText(),
+                        r.get("subject").asText(),
+                        r.get("data").binaryValue()));
 
             } catch (Exception e) {
                 throw new RuntimeException("Failed to process change event", e);

--- a/src/main/java/com/p14n/postevent/LocalConsumer.java
+++ b/src/main/java/com/p14n/postevent/LocalConsumer.java
@@ -1,0 +1,53 @@
+package com.p14n.postevent;
+
+import io.debezium.engine.ChangeEvent;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class LocalConsumer {
+    private final Debezium debezium;
+    private final MessageBroker<Event> broker;
+    private final PostEventConfig config;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public LocalConsumer(PostEventConfig config, MessageBroker<Event> broker) {
+        this.config = config;
+        this.broker = broker;
+        this.debezium = new Debezium();
+    }
+
+    public void start() throws IOException, InterruptedException {
+        Consumer<ChangeEvent<String, String>> consumer = record -> {
+            try {
+
+                try {
+                    var actualObj = mapper.readTree(record.value());
+                    var r = actualObj.get("payload").get("after");
+
+                    broker.publish(Event.create(r.get("id").asText(),
+                            r.get("source").asText(),
+                            r.get("type").asText(),
+                            r.get("datacontenttype").asText(),
+                            r.get("dataschema").asText(),
+                            r.get("subject").asText(),
+                            r.get("data").binaryValue()));
+
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to process change event", e);
+            }
+        };
+
+        debezium.start(config, consumer);
+    }
+
+    public void stop() throws IOException {
+        debezium.stop();
+    }
+}

--- a/src/test/java/com/p14n/postevent/LocalConsumerTest.java
+++ b/src/test/java/com/p14n/postevent/LocalConsumerTest.java
@@ -87,7 +87,7 @@ class LocalConsumerTest {
 
         publisher.publish(testEvent, conn, "test");
 
-        assertTrue(latch.await(5, TimeUnit.SECONDS), "Did not receive event within timeout");
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "Did not receive event within timeout");
 
         Event actual = receivedEvent.get();
         assertNotNull(actual, "No event received");

--- a/src/test/java/com/p14n/postevent/LocalConsumerTest.java
+++ b/src/test/java/com/p14n/postevent/LocalConsumerTest.java
@@ -1,0 +1,99 @@
+package com.p14n.postevent;
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.sql.Connection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LocalConsumerTest {
+    private EmbeddedPostgres pg;
+    private Connection conn;
+    private LocalConsumer localConsumer;
+    private DefaultMessageBroker<Event> broker;
+    private Publisher publisher;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        pg = EmbeddedPostgres.builder()
+                .setServerConfig("wal_level", "logical")
+                .setServerConfig("max_wal_senders", "3")
+                .start();
+
+        conn = pg.getPostgresDatabase().getConnection();
+        var setup = new DatabaseSetup(pg.getJdbcUrl("postgres", "postgres"), "postgres", "postgres");
+        setup.createSchemaIfNotExists();
+        setup.createTableIfNotExists("test");
+
+        broker = new DefaultMessageBroker<>();
+        PostEventConfig config = new ConfigData(
+                "test",
+                "test",
+                "localhost",
+                pg.getPort(),
+                "postgres",
+                "postgres",
+                "postgres",
+                null);
+
+        publisher = new Publisher();
+        localConsumer = new LocalConsumer(config, broker);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (localConsumer != null) {
+            localConsumer.stop();
+        }
+        if (conn != null) {
+            conn.close();
+        }
+        if (pg != null) {
+            pg.close();
+        }
+    }
+
+    @Test
+    void shouldReceivePublishedEvent() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Event> receivedEvent = new AtomicReference<>();
+
+        // Setup consumer
+        broker.subscribe(new MessageSubscriber<Event>() {
+            @Override
+            public void onMessage(Event event) {
+                receivedEvent.set(event);
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                throw new RuntimeException(error);
+            }
+        });
+
+        localConsumer.start();
+
+        // Create and publish test event
+        Event testEvent = new Event(
+                "test-id", "test-source", "test-type",
+                "text/plain", "test-schema", "test-subject",
+                "test-data".getBytes());
+
+        publisher.publish(testEvent, conn, "test");
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "Did not receive event within timeout");
+
+        Event actual = receivedEvent.get();
+        assertNotNull(actual, "No event received");
+        assertEquals(testEvent.id(), actual.id());
+        assertEquals(testEvent.source(), actual.source());
+        assertEquals(testEvent.type(), actual.type());
+        assertArrayEquals(testEvent.data(), actual.data());
+    }
+}

--- a/src/test/java/com/p14n/postevent/LocalConsumerTest.java
+++ b/src/test/java/com/p14n/postevent/LocalConsumerTest.java
@@ -94,6 +94,10 @@ class LocalConsumerTest {
         assertEquals(testEvent.id(), actual.id());
         assertEquals(testEvent.source(), actual.source());
         assertEquals(testEvent.type(), actual.type());
+        assertEquals(testEvent.datacontenttype(), actual.datacontenttype());
+        assertEquals(testEvent.dataschema(), actual.dataschema());
+        assertEquals(testEvent.subject(), actual.subject());
         assertArrayEquals(testEvent.data(), actual.data());
+
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Implement a local consumer to receive events published to a Postgres database via Debezium.

New Features:
- Add a `LocalConsumer` that subscribes to a message broker and receives events published to a Postgres database via Debezium.

Tests:
- Add tests for the `LocalConsumer` to verify event reception and data integrity.