### PR TITLE
Augment catchup latest

### DIFF
--- a/app/infra/tf/rds.tf
+++ b/app/infra/tf/rds.tf
@@ -30,7 +30,8 @@ resource "aws_db_instance" "postevent" {
   identifier                   = "postevent-${count.index}"
   engine                       = "postgres"
   engine_version               = "17"
-  instance_class               = "db.t3.micro"
+  instance_class               = "db.t4g.micro"
+  storage_type                 = "gp3"
   allocated_storage            = 20
   storage_encrypted            = true
   performance_insights_enabled = true

--- a/app/src/main/java/com/p14n/postevent/App.java
+++ b/app/src/main/java/com/p14n/postevent/App.java
@@ -139,8 +139,7 @@ public class App {
                 }
 
             } else {
-                Thread.currentThread().join();
-                // writeContinuously(ds, affinity, write, ot);
+                writeContinuously(ds, affinity, write, ot);
             }
 
         } finally {
@@ -168,8 +167,9 @@ public class App {
                 .sslContext(buildSslContext());
     }
 
-    private static RemotePersistentConsumer runConsumerClient(String[] write, String[] read, String[] topichosts, DataSource ds,
-                                                              OpenTelemetry ot) {
+    private static RemotePersistentConsumer runConsumerClient(String[] write, String[] read, String[] topichosts,
+            DataSource ds,
+            OpenTelemetry ot) {
 
         RemotePersistentConsumer cc;
         cc = new RemotePersistentConsumer(ot, 10);

--- a/library/src/main/java/com/p14n/postevent/broker/SystemEvent.java
+++ b/library/src/main/java/com/p14n/postevent/broker/SystemEvent.java
@@ -5,7 +5,8 @@ import com.p14n.postevent.data.Traceable;
 public enum SystemEvent implements Traceable {
 
     CatchupRequired,
-    UnprocessedCheckRequired;
+    UnprocessedCheckRequired,
+    FetchLatest; // New event type
 
     public String topic;
 

--- a/library/src/main/java/com/p14n/postevent/catchup/CatchupServer.java
+++ b/library/src/main/java/com/p14n/postevent/catchup/CatchupServer.java
@@ -65,4 +65,27 @@ public class CatchupServer implements CatchupServerInterface {
             throw new RuntimeException("Failed to fetch events", e);
         }
     }
+
+    @Override
+    public long getLatestMessageId(String topic) {
+        if (topic == null || topic.trim().isEmpty()) {
+            throw new IllegalArgumentException("Topic name cannot be null or empty");
+        }
+
+        String sql = String.format("SELECT MAX(idn) FROM postevent.%s", topic);
+
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql);
+                ResultSet rs = stmt.executeQuery()) {
+
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+            return 0;
+
+        } catch (SQLException e) {
+            logger.atError().setCause(e).log("Error fetching latest message ID");
+            throw new RuntimeException("Failed to fetch latest message ID", e);
+        }
+    }
 }

--- a/library/src/main/java/com/p14n/postevent/catchup/CatchupServerInterface.java
+++ b/library/src/main/java/com/p14n/postevent/catchup/CatchupServerInterface.java
@@ -17,4 +17,12 @@ public interface CatchupServerInterface {
      * @return A list of events within the specified range
      */
     List<Event> fetchEvents(long startAfter, long end, int maxResults, String topic);
+
+    /**
+     * Retrieves the latest message ID for a given topic.
+     *
+     * @param topic The topic to get the latest message ID for
+     * @return The latest message ID for the specified topic
+     */
+    long getLatestMessageId(String topic);
 }

--- a/library/src/main/java/com/p14n/postevent/catchup/CatchupService.java
+++ b/library/src/main/java/com/p14n/postevent/catchup/CatchupService.java
@@ -186,6 +186,66 @@ public class CatchupService implements MessageSubscriber<SystemEvent>, OneAtATim
     public void onMessage(SystemEvent message) {
         if (Objects.requireNonNull(message) == SystemEvent.CatchupRequired) {
             oneAtATime(() -> catchup(message.topic), () -> onMessage(message));
+        } else if (message == SystemEvent.FetchLatest) {
+            oneAtATime(() -> fetchLatest(message.topic), () -> onMessage(message));
+        }
+    }
+
+    private int fetchLatest(String topicName) {
+        if (topicName == null) {
+            LOGGER.warn("Topic name is null for fetch latest");
+            return 0;
+        }
+
+        try (Connection conn = datasource.getConnection()) {
+            conn.setAutoCommit(false);
+
+            long currentHwm = getCurrentHwm(conn, topicName);
+
+            // Get the latest message ID from the server
+            long latestMessageId = catchupServer.getLatestMessageId(topicName);
+
+            if (latestMessageId <= currentHwm) {
+                LOGGER.info("No new messages found after HWM {} for topic {}", currentHwm, topicName);
+                return 0;
+            }
+
+            // Fetch just the latest message
+            List<Event> events = catchupServer.fetchEvents(latestMessageId, latestMessageId, 1, topicName);
+
+            if (events.isEmpty()) {
+                LOGGER.info("No events found in range for topic: " + topicName);
+                return 0;
+            }
+
+            // Write event to messages table
+            int processedCount = writeEventsToMessagesTable(conn, events);
+
+            LOGGER.info("Processed latest event for topic {}",
+                    topicName);
+
+            conn.commit();
+
+            // If there are more messages between currentHwm and latestMessageId,
+            // trigger a catchup to get the rest
+            systemEventBroker.publish(SystemEvent.CatchupRequired.withTopic(topicName));
+
+            return processedCount;
+        } catch (SQLException e) {
+            LOGGER.error("Failed to fetch latest", e);
+            return 0;
+        }
+    }
+
+    private long findLatestMessageId(Connection connection, String topicName) throws SQLException {
+        String sql = "SELECT MAX(idn) FROM postevent." + topicName;
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+                return 0;
+            }
         }
     }
 

--- a/library/src/main/java/com/p14n/postevent/catchup/CatchupService.java
+++ b/library/src/main/java/com/p14n/postevent/catchup/CatchupService.java
@@ -211,7 +211,7 @@ public class CatchupService implements MessageSubscriber<SystemEvent>, OneAtATim
             }
 
             // Fetch just the latest message
-            List<Event> events = catchupServer.fetchEvents(latestMessageId, latestMessageId, 1, topicName);
+            List<Event> events = catchupServer.fetchEvents(latestMessageId - 1, latestMessageId, 1, topicName);
 
             if (events.isEmpty()) {
                 LOGGER.info("No events found in range for topic: " + topicName);

--- a/library/src/main/java/com/p14n/postevent/catchup/grpc/CatchupGrpcClient.java
+++ b/library/src/main/java/com/p14n/postevent/catchup/grpc/CatchupGrpcClient.java
@@ -86,6 +86,26 @@ public class CatchupGrpcClient implements CatchupServerInterface, AutoCloseable 
     }
 
     @Override
+    public long getLatestMessageId(String topic) {
+        logger.atInfo()
+                .addArgument(topic)
+                .log("Fetching latest message ID for topic {}");
+
+        TopicRequest request = TopicRequest.newBuilder()
+                .setTopic(topic)
+                .build();
+
+        LatestMessageIdResponse response;
+        try {
+            response = blockingStub.getLatestMessageId(request);
+            return response.getMessageId();
+        } catch (StatusRuntimeException e) {
+            logger.atWarn().setCause(e).log("RPC failed: {}", e.getStatus());
+            throw new RuntimeException("Failed to fetch latest message ID via gRPC", e);
+        }
+    }
+
+    @Override
     public void close() {
         try {
             channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);

--- a/library/src/main/java/com/p14n/postevent/catchup/grpc/CatchupGrpcServer.java
+++ b/library/src/main/java/com/p14n/postevent/catchup/grpc/CatchupGrpcServer.java
@@ -60,6 +60,23 @@ public class CatchupGrpcServer {
         }
 
         @Override
+        public void getLatestMessageId(TopicRequest request, StreamObserver<LatestMessageIdResponse> responseObserver) {
+            try {
+                long latestId = catchupServer.getLatestMessageId(request.getTopic());
+
+                LatestMessageIdResponse response = LatestMessageIdResponse.newBuilder()
+                        .setMessageId(latestId)
+                        .build();
+
+                responseObserver.onNext(response);
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                logger.error("Error getting latest message ID", e);
+                responseObserver.onError(e);
+            }
+        }
+
+        @Override
         public void fetchEvents(FetchEventsRequest request, StreamObserver<FetchEventsResponse> responseObserver) {
             try {
                 List<Event> events = catchupServer.fetchEvents(

--- a/library/src/main/java/com/p14n/postevent/db/DatabaseSetup.java
+++ b/library/src/main/java/com/p14n/postevent/db/DatabaseSetup.java
@@ -62,7 +62,7 @@ public class DatabaseSetup {
                 return this;
             }
             for (var slotName : slotNames) {
-                try (var call = conn.prepareCall("call pg_drop_replication_slot(?)")) {
+                try (var call = conn.prepareCall("select pg_drop_replication_slot(?)")) {
                     call.setString(1, slotName);
                     call.execute();
                 }

--- a/library/src/main/proto/catchup.proto
+++ b/library/src/main/proto/catchup.proto
@@ -10,6 +10,8 @@ package catchup;
 service CatchupService {
   // Fetch events from a specific point
   rpc FetchEvents (FetchEventsRequest) returns (FetchEventsResponse) {}
+  // Get the latest message ID for a topic
+  rpc GetLatestMessageId (TopicRequest) returns (LatestMessageIdResponse) {}
 }
 
 // The request message containing fetch parameters
@@ -37,4 +39,12 @@ message Event {
   string time = 8;
   int64 idn = 9;
   string traceparent = 10;
+}
+
+message TopicRequest {
+  string topic = 1;
+}
+
+message LatestMessageIdResponse {
+  int64 message_id = 1;
 }


### PR DESCRIPTION
Fixes #34

## Summary by Sourcery

Introduce a mechanism to periodically fetch the single latest event for each topic, ensuring recent data is processed quickly before a full catchup occurs.

New Features:
- Add a "fetch latest" capability to retrieve and process only the newest event per topic.

Bug Fixes:
- Fix the SQL function call for dropping PostgreSQL replication slots (`call` -> `select`).
- Enable the continuous writing functionality in the main application.

Enhancements:
- Integrate the "fetch latest" trigger into the periodic background tasks for both local and remote consumers.
- Expose the latest message ID retrieval via a new gRPC endpoint.

Deployment:
- Update the AWS RDS instance configuration to use `db.t4g.micro` instance class and `gp3` storage type.