### PR TITLE
Return generated idn on publish

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ compileJava {
 }
 
 group = 'com.p14n'
-version = '1.3.3'
+version = '1.3.4-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ compileJava {
 }
 
 group = 'com.p14n'
-version = '1.3.3-SNAPSHOT'
+version = '1.3.3'
 
 repositories {
     mavenCentral()

--- a/core/src/main/java/com/p14n/postevent/data/Event.java
+++ b/core/src/main/java/com/p14n/postevent/data/Event.java
@@ -111,4 +111,7 @@ public record Event(
 
         return new Event(id, source, type, datacontenttype, dataschema, subject, data, time, idn, topic, traceparent);
     }
+    public  Event withIdn(Long idn){
+        return new Event(id, source, type, datacontenttype, dataschema, subject, data, time, idn, topic, traceparent);
+    }
 }

--- a/debezium/build.gradle
+++ b/debezium/build.gradle
@@ -9,7 +9,7 @@ compileJava {
 }
 
 group = 'com.p14n'
-version = '1.3.3'
+version = '1.3.4-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/debezium/build.gradle
+++ b/debezium/build.gradle
@@ -9,7 +9,7 @@ compileJava {
 }
 
 group = 'com.p14n'
-version = '1.3.3-SNAPSHOT'
+version = '1.3.3'
 
 repositories {
     mavenCentral()

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -15,7 +15,7 @@ compileJava {
 }
 
 group = 'com.p14n'
-version = '1.3.3'
+version = '1.3.4-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -15,7 +15,7 @@ compileJava {
 }
 
 group = 'com.p14n'
-version = '1.3.3-SNAPSHOT'
+version = '1.3.3'
 
 repositories {
     mavenCentral()
@@ -32,7 +32,7 @@ dependencies {
     implementation 'io.grpc:grpc-stub:1.53.0'
     implementation 'io.grpc:grpc-api:1.53.0'
 
-    implementation 'javax.annotation:javax.annotation-api:1.3.3-SNAPSHOT'
+    implementation 'javax.annotation:javax.annotation-api:1.3.3'
     
     // For code generation
     implementation 'com.google.protobuf:protobuf-java:3.21.7'

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'io.grpc:grpc-stub:1.53.0'
     implementation 'io.grpc:grpc-api:1.53.0'
 
-    implementation 'javax.annotation:javax.annotation-api:1.3.3'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
     
     // For code generation
     implementation 'com.google.protobuf:protobuf-java:3.21.7'

--- a/vertx/build.gradle
+++ b/vertx/build.gradle
@@ -15,7 +15,7 @@ compileJava {
 }
 
 group = 'com.p14n'
-version = '1.3.3'
+version = '1.3.4-SNAPSHOT'
 
 
 repositories {

--- a/vertx/build.gradle
+++ b/vertx/build.gradle
@@ -15,7 +15,7 @@ compileJava {
 }
 
 group = 'com.p14n'
-version = '1.3.3-SNAPSHOT'
+version = '1.3.3'
 
 
 repositories {

--- a/vertx/src/main/java/com/p14n/postevent/vertx/adapter/EventBusMessageBroker.java
+++ b/vertx/src/main/java/com/p14n/postevent/vertx/adapter/EventBusMessageBroker.java
@@ -108,11 +108,12 @@ public class EventBusMessageBroker extends EventMessageBroker {
 
             executor.submit(() -> {
                 try {
-                    Publisher.publish(event, dataSource, topic);
+                    Long idn = Publisher.publish(event, dataSource, topic);
 
                     // Then, publish to EventBus for real-time distribution
                     String eventBusAddress = "events." + topic;
-                    eventBus.publish(eventBusAddress, event);
+
+                    eventBus.publish(eventBusAddress, event.withIdn(idn));
 
                     logger.atDebug()
                             .addArgument(topic)
@@ -150,11 +151,11 @@ public class EventBusMessageBroker extends EventMessageBroker {
 
             try {
 
-                Publisher.publish(event.event(), event.connection(), topic);
+                Long idn = Publisher.publish(event.event(), event.connection(), topic);
 
                 // Then, publish to EventBus for real-time distribution
                 String eventBusAddress = "events." + topic;
-                eventBus.publish(eventBusAddress, event.event());
+                eventBus.publish(eventBusAddress, event.event().withIdn(idn));
 
                 logger.atDebug()
                         .addArgument(topic)

--- a/vertx/src/test/java/com/p14n/postevent/vertx/example/VertxConsumerExample.java
+++ b/vertx/src/test/java/com/p14n/postevent/vertx/example/VertxConsumerExample.java
@@ -43,7 +43,7 @@ public class VertxConsumerExample {
                     "text",
                     null,
                     "test",
-                    "hello".getBytes(), Instant.now(),1L ,"order",null));
+                    "hello".getBytes(), Instant.now(),null ,"order",null));
 
             client.subscribe("order", message -> {
                 System.out.println("Got message");
@@ -56,7 +56,7 @@ public class VertxConsumerExample {
                     "text",
                     null,
                     "test",
-                    "hello".getBytes(), Instant.now(),2L ,"order",null));
+                    "hello".getBytes(), Instant.now(),null ,"order",null));
 
             latch.await(10, TimeUnit.SECONDS);
 


### PR DESCRIPTION
## Summary by Sourcery

Return database-generated idn in publish calls, propagate it through the EventBus, provide an Event.withIdn helper, and update project versions to 1.3.3.

New Features:
- Return the generated idn from Publisher.publish and propagate it to the Vert.x EventBus
- Add withIdn method to Event to create a copy with the generated idn

Build:
- Bump module versions from 1.3.3-SNAPSHOT to 1.3.3 across core, grpc, debezium, and vertx
- Update javax.annotation-api dependency to release version 1.3.3

Tests:
- Adjust VertxConsumerExample to omit manual idn assignment and handle null idn